### PR TITLE
Add test for XMLSequenceStream

### DIFF
--- a/tests/fixtures/stream-xml-with-encoding.xml
+++ b/tests/fixtures/stream-xml-with-encoding.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="database_name_1">
+    <table_data name="table1">
+    <row>
+        <field name="table1_id">1</field>
+        <field name="column1">tgfahgasdf</field>
+        <field name="column2">200</field>
+        <field name="column3">34.64</field>
+        <field name="column4">yghkf;a  hahfg8ja h;</field>
+    </row>
+    <row>
+        <field name="table1_id">2</field>
+        <field name="column1">hk;afg</field>
+        <field name="column2">654</field>
+        <field name="column3">46.54</field>
+        <field name="column4">24rwehhads</field>
+    </row>
+    <row>
+        <field name="table1_id">3</field>
+        <field name="column1">ha;gyt</field>
+        <field name="column2">462</field>
+        <field name="column3">1654.4</field>
+        <field name="column4">asfgklg</field>
+    </row>
+    </table_data>
+    <table_data name="table2">
+    <row>
+        <field name="table2_id">1</field>
+        <field name="column5">fhah</field>
+        <field name="column6">456</field>
+        <field name="column7">46.5</field>
+        <field name="column8">fsdbghfdas</field>
+    </row>
+    <row>
+        <field name="table2_id">2</field>
+        <field name="column5">asdhfoih</field>
+        <field name="column6">654</field>
+        <field name="column7" xsi:nil="true" />
+        <field name="column8">43asdfhgj</field>
+    </row>
+    <row>
+        <field name="table2_id">3</field>
+        <field name="column5">ajsdlkfguitah</field>
+        <field name="column6">654</field>
+        <field name="column7" xsi:nil="true" />
+        <field name="column8" xsi:nil="true" />
+    </row>
+    </table_data>
+</database>
+</mysqldump>
+<?xml version="1.0" encoding="UTF-8"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="database_name_2">
+    <table_data name="table3">
+        <row>
+            <field name="table3_id">1</field>
+            <field name="column1">tgfahgasdf</field>
+            <field name="column2">200</field>
+            <field name="column3">34.64</field>
+            <field name="column4">yghkf;a  hahfg8ja h;</field>
+        </row>
+        <row>
+            <field name="table3_id">2</field>
+            <field name="column1">hk;afg</field>
+            <field name="column2">654</field>
+            <field name="column3">46.54</field>
+            <field name="column4">24rwehhads</field>
+        </row>
+        <row>
+            <field name="table3_id">3</field>
+            <field name="column1">ha;gyt</field>
+            <field name="column2">462</field>
+            <field name="column3">1654.4</field>
+            <field name="column4">asfgklg</field>
+        </row>
+    </table_data>
+    <table_data name="table4">
+        <row>
+            <field name="table4_id">1</field>
+            <field name="column5">fhah</field>
+            <field name="column6">456</field>
+            <field name="column7">46.5</field>
+            <field name="column8">fsdbghfdas</field>
+        </row>
+        <row>
+            <field name="table4_id">2</field>
+            <field name="column5">asdhfoih</field>
+            <field name="column6">654</field>
+            <field name="column7" xsi:nil="true" />
+            <field name="column8">43asdfhgj</field>
+        </row>
+        <row>
+            <field name="table4_id">3</field>
+            <field name="column5">ajsdlkfguitah</field>
+            <field name="column6">654</field>
+            <field name="column7" xsi:nil="true" />
+            <field name="column8" xsi:nil="true" />
+        </row>
+    </table_data>
+</database>
+</mysqldump>

--- a/tests/fixtures/stream-xml-without-encoding.xml
+++ b/tests/fixtures/stream-xml-without-encoding.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="database_name_1">
+    <table_data name="table1">
+    <row>
+        <field name="table1_id">1</field>
+        <field name="column1">tgfahgasdf</field>
+        <field name="column2">200</field>
+        <field name="column3">34.64</field>
+        <field name="column4">yghkf;a  hahfg8ja h;</field>
+    </row>
+    <row>
+        <field name="table1_id">2</field>
+        <field name="column1">hk;afg</field>
+        <field name="column2">654</field>
+        <field name="column3">46.54</field>
+        <field name="column4">24rwehhads</field>
+    </row>
+    <row>
+        <field name="table1_id">3</field>
+        <field name="column1">ha;gyt</field>
+        <field name="column2">462</field>
+        <field name="column3">1654.4</field>
+        <field name="column4">asfgklg</field>
+    </row>
+    </table_data>
+    <table_data name="table2">
+    <row>
+        <field name="table2_id">1</field>
+        <field name="column5">fhah</field>
+        <field name="column6">456</field>
+        <field name="column7">46.5</field>
+        <field name="column8">fsdbghfdas</field>
+    </row>
+    <row>
+        <field name="table2_id">2</field>
+        <field name="column5">asdhfoih</field>
+        <field name="column6">654</field>
+        <field name="column7" xsi:nil="true" />
+        <field name="column8">43asdfhgj</field>
+    </row>
+    <row>
+        <field name="table2_id">3</field>
+        <field name="column5">ajsdlkfguitah</field>
+        <field name="column6">654</field>
+        <field name="column7" xsi:nil="true" />
+        <field name="column8" xsi:nil="true" />
+    </row>
+    </table_data>
+</database>
+</mysqldump>
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="database_name_2">
+    <table_data name="table3">
+        <row>
+            <field name="table3_id">1</field>
+            <field name="column1">tgfahgasdf</field>
+            <field name="column2">200</field>
+            <field name="column3">34.64</field>
+            <field name="column4">yghkf;a  hahfg8ja h;</field>
+        </row>
+        <row>
+            <field name="table3_id">2</field>
+            <field name="column1">hk;afg</field>
+            <field name="column2">654</field>
+            <field name="column3">46.54</field>
+            <field name="column4">24rwehhads</field>
+        </row>
+        <row>
+            <field name="table3_id">3</field>
+            <field name="column1">ha;gyt</field>
+            <field name="column2">462</field>
+            <field name="column3">1654.4</field>
+            <field name="column4">asfgklg</field>
+        </row>
+    </table_data>
+    <table_data name="table4">
+        <row>
+            <field name="table4_id">1</field>
+            <field name="column5">fhah</field>
+            <field name="column6">456</field>
+            <field name="column7">46.5</field>
+            <field name="column8">fsdbghfdas</field>
+        </row>
+        <row>
+            <field name="table4_id">2</field>
+            <field name="column5">asdhfoih</field>
+            <field name="column6">654</field>
+            <field name="column7" xsi:nil="true" />
+            <field name="column8">43asdfhgj</field>
+        </row>
+        <row>
+            <field name="table4_id">3</field>
+            <field name="column5">ajsdlkfguitah</field>
+            <field name="column6">654</field>
+            <field name="column7" xsi:nil="true" />
+            <field name="column8" xsi:nil="true" />
+        </row>
+    </table_data>
+</database>
+</mysqldump>

--- a/tests/unit/XMLStreamReaderTest.php
+++ b/tests/unit/XMLStreamReaderTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * This file is part of the XMLReaderIterator package.
+ *
+ * Copyright (C) 2014 hakre <http://hakre.wordpress.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author hakre <http://hakre.wordpress.com>
+ * @license AGPL-3.0 <http://spdx.org/licenses/AGPL-3.0>
+ */
+
+/**
+ * Class XMLReaderTest
+ */
+class XMLStreamReaderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideFile
+     */
+    function readStreamTest($xmlFile)
+    {
+        stream_wrapper_register('xmlseq', 'XMLSequenceStream');
+        $path = "xmlseq://" . $xmlFile;
+
+        $this->xmlFileContents = array();
+        while (XMLSequenceStream::notAtEndOfSequence($path)) {
+            $reader = new XMLReader();
+            $reader->open($path, 'UTF-8', LIBXML_COMPACT | LIBXML_PARSEHUGE);
+            /** @var XMLElementIterator|XMLReaderNode $elements */
+            $elements = new XMLElementIterator($reader);
+            $this->xmlFileContents[] = new SimpleXMLElement(
+                $elements->current()->readOuterXml()
+            );
+        }
+
+        XMLSequenceStream::clean();
+        stream_wrapper_unregister('xmlseq');
+    }
+
+    public function provideFile()
+    {
+        return array(
+            array(
+                __DIR__ . '/../fixtures/stream-xml-with-encoding.xml'
+            ),
+            array(
+                __DIR__ . '/../fixtures/stream-xml-without-encoding.xml'
+            )
+        );
+    }
+}


### PR DESCRIPTION
When the xml file contain several xml documents declarations without
encoding, XMLReader fails to load current node.

Is this an issue with XMLReader? Can we make a workaround for this?

Similar outputs as in test fixtures ca be obtained with `mysqldump --xml` tool, concatenating several outputs. mysqldump uses utf-8 by default but it seems that XMLReader fails even is utf-8 is enforced when reading with it. 

Thanks in advance