### PR TITLE
Double self::next() call caused skipping first element in XMLReaderIterator class

### DIFF
--- a/src/XMLReaderIterator.php
+++ b/src/XMLReaderIterator.php
@@ -68,7 +68,6 @@ class XMLReaderIterator implements Iterator, XMLReaderAggregate
             if (!$name || $name === $this->reader->name) {
                 break;
             }
-            self::next();
         }
         ;
 


### PR DESCRIPTION
Fix issue with iteration when you never could select the first row as iterator logic had the bug with 2 next() calls invocations which lead to selection elements from array since 2nd element, we had many issues due to this in our migration implementation.