### PR TITLE
Allow nested xpath filter

### DIFF
--- a/src/XMLElementXpathFilter.php
+++ b/src/XMLElementXpathFilter.php
@@ -46,10 +46,10 @@ class XMLElementXpathFilter extends XMLReaderFilterBase
         $buffer = $this->getInnerIterator()->getNodeTree();
         $result = simplexml_load_string($buffer)->xpath($this->expression);
         $count  = count($result);
-        if ($count !== 1) {
+        if ($count < 1) {
             return false;
         }
 
-        return !($result[0]->children()->count());
+        return !($result[$count - 1]->children()->count());
     }
 }


### PR DESCRIPTION
Hi @hakre . Thanks for the library.

This PR resolves #12 . The problem is, that the current XPathFilter only check for exactly one match. If there nested matches, they are not found.

## Behavior:

Using example in https://github.com/hakre/XMLReaderIterator/issues/12#issuecomment-276355968 with this script:

~~~php
$xml = <<<XML
<response>
  <entry>
    <log>
      <logs count="3">
        <entry id="1">
          <baz>1</baz>
        </entry>
        <entry id="2">
          <baz>2</baz>
        </entry>
        <entry id="3">
          <baz>3</baz>
        </entry>
      </logs>
    </log>
  </entry>
</response>
XML;


$reader = XMLReader::open('data://text/plain,' . urlencode($xml));
$iterator = new XMLElementIterator($reader);
$list = new \XMLElementXpathFilter($iterator, '//entry');


/** @var \XMLReaderNode $result */
foreach($list as $item) {
    var_dump($item->getName());
    var_dump($item->getAttribute('id'));
}
~~~

### Before patch

~~~
string(5) "entry"
NULL
~~~

### After patch

~~~
string(5) "entry"
NULL
string(5) "entry"
string(1) "1"
string(5) "entry"
string(1) "2"
string(5) "entry"
string(1) "3"
~~~
