### PR TITLE
Nested child element parsing

### DIFF
--- a/examples/child-nested-read.php
+++ b/examples/child-nested-read.php
@@ -1,0 +1,19 @@
+<?php
+
+require('xmlreader-iterators.php'); // require XMLReaderIterator library
+
+$xmlFile = 'data/products.xml';
+
+/** @var \Traversable<int,\XMLReaderNode> $list */
+$iterator = new XMLElementIterator(XMLReader::open($xmlFile));
+$list     = new XMLElementXpathFilter($iterator, '//product');
+
+foreach ($list as $item) {
+    printf('Found product "%s"' . \PHP_EOL, $item->getAttribute('sku'));
+
+    foreach ($item->getChildElements('attributes') as $attributeList) {
+        foreach ($attributeList->getChildElements() as $attribute) {
+            printf('  - %s: %s' . \PHP_EOL, $attribute->name, (string)$attribute);
+        }
+    }
+}

--- a/examples/data/products.xml
+++ b/examples/data/products.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<catalog>
+    <product sku="empty_product"/>
+    <product sku="empty_attributes">
+        <attributes/>
+    </product>
+    <product sku="no_attributes">
+    </product>
+    <product sku="foo">
+        <attributes>
+            <name>Test product</name>
+        </attributes>
+        <variants>
+            <product sku="foo_blue">
+                <attributes>
+                    <name>Test product in blue</name>
+                    <price>15.00</price>
+                </attributes>
+            </product>
+            <product sku="foo_red">
+                <attributes>
+                    <name>Test product in red</name>
+                    <price>12.00</price>
+                </attributes>
+            </product>
+        </variants>
+    </product>
+    <product sku="bar">
+        <attributes>
+            <name>Simple test product</name>
+            <price>10.99</price>
+        </attributes>
+    </product>
+    <product sku="foobar">
+        <attributes>
+            <name>Another product</name>
+            <price>99.99</price>
+        </attributes>
+        <variants>
+            <product sku="foobar_l">
+                <attributes>
+                    <size>L</size>
+                </attributes>
+            </product>
+            <product sku="foobar_m">
+                <attributes>
+                    <size>M</size>
+                </attributes>
+            </product>
+        </variants>
+    </product>
+</catalog>

--- a/src/XMLReaderIterator.php
+++ b/src/XMLReaderIterator.php
@@ -167,9 +167,15 @@ class XMLReaderIterator implements Iterator, XMLReaderAggregate
         if ($this->skipNextRead) {
             $this->skipNextRead = false;
             $this->lastRead = $this->reader->nodeType !== XMLReader::NONE;
-        } elseif ($this->lastRead = $this->reader->read() and $this->reader->nodeType === XMLReader::ELEMENT) {
+        } elseif ($this->lastRead = $this->readNext() and $this->reader->nodeType === XMLReader::ELEMENT) {
             $this->touchElementStack();
         }
+    }
+
+    #[\ReturnTypeWillChange]
+    protected function readNext()
+    {
+        return $this->reader->read();
     }
 
     /**

--- a/tests/functional/examples/Expectations/child-nested-read_php.out
+++ b/tests/functional/examples/Expectations/child-nested-read_php.out
@@ -1,0 +1,21 @@
+Found product "empty_product"
+Found product "empty_attributes"
+Found product "no_attributes"
+Found product "foo"
+  - name: Test product
+Found product "foo_blue"
+  - name: Test product in blue
+  - price: 15.00
+Found product "foo_red"
+  - name: Test product in red
+  - price: 12.00
+Found product "bar"
+  - name: Simple test product
+  - price: 10.99
+Found product "foobar"
+  - name: Another product
+  - price: 99.99
+Found product "foobar_l"
+  - size: L
+Found product "foobar_m"
+  - size: M

--- a/tests/unit/XMLChildElementIteratorTest.php
+++ b/tests/unit/XMLChildElementIteratorTest.php
@@ -91,7 +91,6 @@ class XMLChildElementIteratorTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($expected[$index], $reader->name);
         }
         $this->assertEquals(count($expected), $count);
-
     }
 
     /**
@@ -141,5 +140,27 @@ class XMLChildElementIteratorTest extends PHPUnit_Framework_TestCase
         $this->assertSame(13, $index, 'movies.xml document element has 14 child elements');
         $array = iterator_to_array($children, false);
         $this->assertSame(array(), $array, 'all children have been consumed by foreach');
+    }
+
+    /**
+     * Test child-iterator without calling 'skipNextRead' method
+     */
+    public function testIterationOnChildrenStopBeforeReadingNextElement()
+    {
+        $reader = XMLReader::open(__DIR__ . '/../../examples/data/sample-rss-091.xml');
+        $this->assertTrue(!!$reader, 'fixture document can be opened successfully');
+        $items = new XMLElementIterator($reader, 'item');
+        foreach ($items as $idx => $item) {
+            $children = $items->getChildElements();
+            $children->rewind();
+            foreach (array('title', 'link', 'description') as $tagName) {
+                $this->assertTrue($children->valid());
+                $this->assertSame($tagName, $children->name);
+                $children->next();
+            }
+            $this->assertFalse($children->valid());
+        }
+        $this->assertSame(6, $idx, 'sample-rss-091.xml element has 7 item elements');
+        $this->assertEmpty(\iterator_to_array($items), 'all children have been consumed by foreach');
     }
 }


### PR DESCRIPTION
Since Release v0.1.11 there is the `\XMLReaderIterator::skipNextRead` to fix reading children and continue iteration for parent nodes.

In current project parsing of children is extracted to different objects and it is not easy, to decide, if this method have to call or not. Also this method feels like a workaround and I think, this should be part of the reader itself.

I modified the `XMLChildElementIterator.php`, that he can break before `XMLReader` reads the next node, that isn't a child by using the node-type `XMLReader::END_ELEMENT`

On the example, I also add some different use-cases like empty children or parent is a self-closing-tag.

I recognize, you use a lot of `self::` instead of `$this` (I think for performance-reasons?) . The only way, that only the `XMLChildElementInterator` can track open/closing-tags and not the `XMLReaderIterator`, which shouldn't care about "do i leave the container", was to extract reading into a protected method. I hope, you are fine with that.

**Note**: Provided example requires #20 

---

* [x] [`jwundrak-nested-child-element-parsing`](https://github.com/hakre/XMLReaderIterator/compare/jwundrak-nested-child-element-parsing) @hakre
* [x] base on develop with #20 (fixes #12) @hakre
* [x] PR rebase
* [x] tests