### PR TITLE
Switch self keyword in callback to class name

### DIFF
--- a/src/XMLBuild.php
+++ b/src/XMLBuild.php
@@ -100,7 +100,7 @@ abstract class XMLBuild
 
         // REC-xml/#AVNormalize - preserve
         // REC-xml/#sec-line-ends - preserve
-        $buffer = preg_replace_callback('~\r\n|\r(?!\n)|\t~', array('self', 'numericEntitiesSingleByte'), $buffer);
+        $buffer = preg_replace_callback('~\r\n|\r(?!\n)|\t~', array('XMLBuild', 'numericEntitiesSingleByte'), $buffer);
 
         return htmlspecialchars($buffer, ENT_QUOTES, 'UTF-8', false);
     }

--- a/src/XMLReaderNode.php
+++ b/src/XMLReaderNode.php
@@ -212,7 +212,7 @@ class XMLReaderNode implements XMLReaderAggregate
      * @throws BadMethodCallException
      * @return DOMNode
      */
-    public function expand(DOMNode $baseNode = null)
+    public function expand(?DOMNode $baseNode = null)
     {
         if (null === $baseNode) {
             $baseNode = new DomDocument();

--- a/src/XMLReaderNode.php
+++ b/src/XMLReaderNode.php
@@ -100,6 +100,37 @@ class XMLReaderNode implements XMLReaderAggregate
     }
 
     /**
+     * Like {@see getSimpleXMLElement()} but strips all XML namespace declarations
+     * from the serialized node before parsing, so that plain XPath expressions
+     * (e.g. ./code) work on feeds that carry a default xmlns="..." attribute.
+     *
+     * @return SimpleXMLElement|null
+     */
+    public function getSimpleXMLElementWithoutNamespaces(): ?\SimpleXMLElement
+    {
+        if ($this->reader->nodeType !== XMLReader::ELEMENT) {
+            return null;
+        }
+
+        $doc = new \DOMDocument();
+        $node = $this->expand($doc);
+        $xml = $doc->saveXML($node);
+
+        if (false === $xml) {
+            return null;
+        }
+
+        $xml = preg_replace('/\s+xmlns(?::\w+)?="[^"]*"/', '', $xml);
+        if (null === $xml) {
+            return null;
+        }
+
+        $element = simplexml_load_string($xml);
+
+        return $element instanceof \SimpleXMLElement ? $element : null;
+    }
+
+    /**
      * @deprecated since v0.1.4, use {@see getSimpleXMLElement()} instead
      * @return null|SimpleXMLElement
      */


### PR DESCRIPTION
I am stuck right now on error: "Use of "self" in callables is deprecated" Yes it is just deprecation, however it still needs fixing.

I didn't see supported php versions so I made it as compatible as possible.